### PR TITLE
Bug - Always On Parachute During Round

### DIFF
--- a/addons/sourcemod/scripting/AdvancedParachute.sp
+++ b/addons/sourcemod/scripting/AdvancedParachute.sp
@@ -20,6 +20,8 @@ public Plugin myinfo =
   url = ""
 };
 
+bool ParachuteBool = true;
+
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
   g_hOnParachute = CreateGlobalForward("OnParachuteOpen", ET_Event, Param_Cell);
@@ -36,6 +38,9 @@ public void OnPluginStart()
   smParachutes = new StringMap();
 
   HookEvent("player_death",Event_OnPlayerDeath);
+
+	HookEvent("round_start", Event_OnRoundStart);
+	HookEvent("round_end", Event_OnRoundEnd);
 
   g_iVelocity = FindSendPropInfo("CBasePlayer", "m_vecVelocity[0]");
   if(g_iVelocity == -1)
@@ -154,16 +159,29 @@ public void OnClientDisconnect_Post(int client)
     g_LastButtons[client] = 0;
 }
 
+public Action Event_OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
+{
+	ParachuteBool = false;
+}
+
+public Action Event_OnRoundStart(Event event, const char[] name, bool dontBroadcast)
+{
+	ParachuteBool = true;
+}
+
 void OnButtonPress(int client, int button)
 {
-  if(IsValidClient(client, true))
-  {
-    int cFlags = GetEntityFlags(client);
-    if(button == IN_USE && g_iParachuteEnt[client] == 0 && IsInAir(client, cFlags))
-    {
-      AttachParachute(client);
-    }
-  }
+	if (ParachuteBool)
+	{
+		if (IsValidClient(client, true))
+		{
+			int cFlags = GetEntityFlags(client);
+			if (button == IN_USE && g_iParachuteEnt[client] == 0 && IsInAir(client, cFlags))
+			{
+				AttachParachute(client);
+			}
+		}
+	}
 }
 
 void OnButtonRelease(int client, int button)

--- a/addons/sourcemod/scripting/AdvancedParachute.sp
+++ b/addons/sourcemod/scripting/AdvancedParachute.sp
@@ -39,8 +39,8 @@ public void OnPluginStart()
 
   HookEvent("player_death",Event_OnPlayerDeath);
 
-	HookEvent("round_start", Event_OnRoundStart);
-	HookEvent("round_end", Event_OnRoundEnd);
+  HookEvent("round_start", Event_OnRoundStart);
+  HookEvent("round_end", Event_OnRoundEnd);
 
   g_iVelocity = FindSendPropInfo("CBasePlayer", "m_vecVelocity[0]");
   if(g_iVelocity == -1)


### PR DESCRIPTION
Bug - Always On Parachute During Round

When the round starts, if the player had the parachute turned on, in the next round the parachute will always be turned on throughout the round without clicking the use button, that is, just jump and the parachute will always turn on, so this change does so players can't hook up the parachute when the round ends.